### PR TITLE
simply: Update link for slinux-tavolga 9.1

### DIFF
--- a/_data/images/p9-simply.yml
+++ b/_data/images/p9-simply.yml
@@ -87,7 +87,7 @@ entries:
     type: archive
     board: BFK3.1 development board
 
-  - link: https://mirror.yandex.ru/altlinux/p9/images/simply/mipsel/tavolga-slinux-9.0-mipsel.recovery.tar
+  - link: http://ftp.altlinux.org/pub/distributions/ALTLinux/p9/images/simply/mipsel/slinux-tavolga-9.1-mipsel.recovery.tar
     platform: p9
     solution: simply
     importance: 0


### PR DESCRIPTION
Now that we've released new image, the link should point to it.
It's not on Yandex mirror yet, so the link points directly
to ftp.a.o.