### PR TITLE
Update p10-kworkstation.yml

### DIFF
--- a/_data/images/p10-kworkstation.yml
+++ b/_data/images/p10-kworkstation.yml
@@ -1,7 +1,7 @@
 ---
 
 entries:
-  - link: https://download.basealt.ru/pub/distributions/ALTLinux/p10/images/kworkstation/alt-kworkstation-10-install-x86_64.iso
+  - link: https://download.basealt.ru/pub/distributions/ALTLinux/p10/images/kworkstation/alt-kworkstation-10.4-install-x86_64.iso
     platform: p10
     solution: alt-kworkstation
     importance: 1
@@ -10,7 +10,7 @@ entries:
     type: iso
     status: release
 
-  - link: https://download.basealt.ru/pub/distributions/ALTLinux/p10/images/kworkstation/alt-kworkstation-10-live-x86_64.iso
+  - link: https://download.basealt.ru/pub/distributions/ALTLinux/p10/images/kworkstation/alt-kworkstation-10.4-live-x86_64.iso
     platform: p10
     solution: alt-kworkstation
     importance: 0


### PR DESCRIPTION
Message during image writing (server boot):
```
This image won't be verified after writing because no MD5 sum was found.
```

The image name in ```p10-kworkstation.yml``` did not match the image name in the md5sum file.
In ```p10-kworkstation.yml```:
```
 alt-kworkstation-10-install-x86_64.iso
```
In the file with md5sum (https://download.basealt.ru/pub/distributions/ALTLinux/p10/images/kworkstation/MD5SUM):
```
No such name
```

Because of which ALT Media Writer cannot check md5sum after downloading the image. The proposed commit fixes the situation - md5sum is checked after writing.